### PR TITLE
Edited ethnic minorities in Metropolitan France (Flemish, Germans, Bretons, Basques, Corsicans and Catalans)

### DIFF
--- a/common/history/pops/00_west_europe.txt
+++ b/common/history/pops/00_west_europe.txt
@@ -521,11 +521,11 @@
 		region_state:FRA = {
 			create_pop = {
 				culture = occitan
-				size = 1517200
+				size = 1471675
 			}
 			create_pop = {
 				culture = catalan
-				size = 111800
+				size = 157325
 			}
 		}
 	}
@@ -557,11 +557,11 @@
 		region_state:FRA = {
 			create_pop = {
 				culture = french
-				size = 2238408
+				size = 2119103
 			}
 			create_pop = {
 				culture = flemish
-				size = 71200
+				size = 190505
 			}
 		}
 	}
@@ -569,7 +569,7 @@
 		region_state:FRA = {
 			create_pop = {
 				culture = french
-				size = 510008
+				size = 191900
 			}
 			create_pop = {
 				culture = ashkenazi
@@ -577,12 +577,12 @@
 			}
 			create_pop = {
 				culture = south_german
-				size = 415992
+				size = 874110
 			}
 			create_pop = {
 				culture = south_german
 				religion = protestant
-				size = 418004
+				size = 294390
 			}
 		}
 	}
@@ -618,11 +618,11 @@
 		region_state:FRA = {
 			create_pop = {
 				culture = french
-				size = 692572
+				size = 1460562
 			}
 			create_pop = {
 				culture = breton
-				size = 1844240
+				size = 1076250
 			}
 		}
 	}
@@ -670,11 +670,11 @@
 		region_state:FRA = {
 			create_pop = {
 				culture = occitan
-				size = 1546844
+				size = 1605894
 			}
 			create_pop = {
 				culture = basque
-				size = 180000
+				size = 120950
 			}
 		}
 	}

--- a/common/history/pops/01_south_europe.txt
+++ b/common/history/pops/01_south_europe.txt
@@ -61,11 +61,11 @@
 		region_state:FRA = { # est. total 196476
 			create_pop = {
 				culture = corsican
-				size = 159146
+				size = 189705
 			}
 			create_pop = {
 				culture = french
-				size = 37330 # pls don't ask where this number comes from
+				size = 6771 # pls don't ask where this number comes from
 			}
 		}
 	}


### PR DESCRIPTION
I edited the population numbers of the ethnic minorities in France at game start, namely the Flemish, South Germans, Bretons, Basques, Corsicans and Catalans. I used the numbers from the following book: 
"Mélanges sur les langues, dialectes et patois, renfermant, entre autres, une collection de versions de la parabole de l'enfant prodigue en cent idiomes ou patois différents, presque tous de France, précédés d'un essai d'un travail sur la géographie de la langue française"
This book was published in 1831 and in it, the authors calculate the numbers for each ethnic minority based on the numbers from 1806, which they extrapolate to 1830. I myself extrapolated these numbers to 1836.