### PR TITLE
central american event chain fix

### DIFF
--- a/events/central_america_events.txt
+++ b/events/central_america_events.txt
@@ -884,7 +884,7 @@ central_america.8 = {
 	
 }
 
-# County rejoins the FRCA
+# Country rejoins the FRCA
 central_america.9 = {
 	type = country_event
 	placement = ROOT
@@ -910,21 +910,31 @@ central_america.9 = {
 	}
 
 	immediate = {
-		random_country = {
+		every_country = {
 			limit = {
-				trigger_if = {
-					country_has_primary_culture = cu:central_american
-				}
-				is_player = no
+				country_has_primary_culture = cu:central_american
+				NOT = { this = root}
 			}
-			save_scope_as = frca_annex_country
+			root = {
+				add_to_variable_list = {
+					name = central_american_countries
+					target = prev
+				}
+			}
 		}
 	}
 
 	option = {
 		name = central_america.9.a
 		default_option = yes
-		annex = scope:frca_annex_country
+		every_in_list = {
+			variable = central_american_countries
+			root = {
+				annex = prev
+			}
+		}
+
+		clear_variable_list = central_american_countries
 		ai_chance = {
 			base = 1
 		}

--- a/localization/english/00_vfm_events_l_english.yml
+++ b/localization/english/00_vfm_events_l_english.yml
@@ -28,9 +28,9 @@
   central_america.8.f:1 ""Education is the soul of the people and the root of the armies of freedom.""
   central_america.8.a:0 "The Union shall prevail"
  
-  central_america.9.t:0 "Costa Rica rejoins the Union!"
-  central_america.9.d:1 "As tensions are quelled across Central America, the assembly in Costa Rica has put forth the request to officiall rejoin the Union!"
-  central_america.9.f:1 ""The nation's soul is split in twain! The border between our lands is a cruel cut at the very heart of our people. It is obvious to all that now is the time for unification!""
+  central_america.9.t:0 "Central America Re-Unites"
+  central_america.9.d:1 "As tensions are quelled across Central America, the different independent states have put forth the request to officially rejoin the Union!"
+  central_america.9.f:1 "The nation's soul is split in twain! The border between our lands is a cruel cut at the very heart of our people. It is obvious to all that now is the time for unification!"
   central_america.9.a:0 "Hurrah!"
 
  # South American Events


### PR DESCRIPTION
this event chain could crash the game when scope:frca_annex_country was not defined but also not all countries were annexed and the country chosen could just be central_america, meaning none were annexed back.