### PR TITLE
Congress Poland hotfix

### DIFF
--- a/common/country_definitions/00_vfm_countries.txt
+++ b/common/country_definitions/00_vfm_countries.txt
@@ -18,7 +18,7 @@ CPL = {
 	
 	country_type = recognized
 
-	tier = kingdom
+	tier = principality
 	
 	cultures = { russian }
 	capital = STATE_WARSAW


### PR DESCRIPTION
By downgrading Congress Poland from kingdom to principality, they are now able to form the Kingdom of Poland